### PR TITLE
fix: Update Go version to 1.26.2 for consistency and setup-envtest compatibility

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,4 +36,4 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@0a35821d5c230e903fcfe077583637dea1b27b47 # v9.0.0
         with:
-          version: v2.5.0
+          version: v2.11.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.25.6-alpine3.22 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.2-alpine3.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/registry-cache
 
-go 1.25.6
+go 1.26.2
 
 require (
 	github.com/gardener/gardener-extension-registry-cache v0.19.0


### PR DESCRIPTION
## Summary
This PR updates the Go version to 1.26.2 to align with other repositories in the project and ensure compatibility with the latest controller-runtime tooling.

## Changes
- Updated go.mod: Go 1.25.6 → 1.26.2
- Updated Dockerfile: golang:1.25.6-alpine3.22 → golang:1.26.2-alpine3.23
- Ran go mod tidy

## Why
- The latest sigs.k8s.io/controller-runtime/tools/setup-envtest requires Go >= 1.26.0
- Ensures consistency across all repositories in the project
- Prevents CI failures due to Go version mismatches

## Testing
After merge, verify that CI checks pass successfully.