### PR TITLE
fix: build-image gate — require approval for all PRs, fix skip propagation

### DIFF
--- a/.github/workflows/build_registry_cache.yml
+++ b/.github/workflows/build_registry_cache.yml
@@ -31,9 +31,7 @@ permissions:
 jobs:
   gate:
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.full_name != github.repository
+    if: github.event_name == 'pull_request_target'
     environment: ${{ vars.PROTECTED_ENVIRONMENT }}
     steps:
       - name: Approve fork PR image build
@@ -66,9 +64,7 @@ jobs:
   build-image:
     name: run-image-builder
     needs: [setup, gate]
-    if: >-
-      needs.setup.result == 'success' &&
-      (needs.gate.result == 'success' || needs.gate.result == 'skipped')
+    if: ${{ !cancelled() && needs.setup.result == 'success' && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: registry-cache


### PR DESCRIPTION
## Problem
The gate job only blocked fork PRs. Upstream branch PRs (Renovate, team members) bypassed the gate, causing build-image to be skipped due to a GitHub Actions quirk: reusable workflow jobs (`uses:`) with a skipped job in their `needs` are silently skipped when the `if` condition is not wrapped in `${{ }}`.

## Fix
- **gate**: removed `head.repo.full_name != github.repository` — all `pull_request_target` events now require approval
- **build-image**: wrapped `if` in `${{ !cancelled() && ... }}` to prevent skip propagation

## Behaviour after fix
| Trigger | gate | build-image |
|---|---|---|
| Tag push | skipped | builds automatically |
| Push to main | skipped | builds automatically |
| Upstream branch PR | waits for approval | builds after approval |
| Fork PR | waits for approval | builds after approval |

## Test plan
- [ ] Open an upstream branch PR and verify gate pauses for approval
- [ ] Approve and verify build-image runs

Mirrors fix from kyma-project/kyma-infrastructure-manager#1460