### PR TITLE
fix: remove experimental tag from build-image on tag push

### DIFF
--- a/.github/workflows/build_registry_cache.yml
+++ b/.github/workflows/build_registry_cache.yml
@@ -45,8 +45,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.tag || '' }}
-      # set to {tag}-experimental if tag is set, otherwise set to empty string
-      tag-experimental: ${{ steps.tag.outputs.tag && format('{0}-experimental', steps.tag.outputs.tag) || '' }}
       latest: ${{ steps.latest.outputs.latest || '' }}
     steps:
       - name: Checkout code
@@ -72,7 +70,6 @@ jobs:
       context: .
       tags: |
         ${{ needs.setup.outputs.tag }}
-        ${{ needs.setup.outputs.tag-experimental }}
         ${{ needs.setup.outputs.latest }}
 
   summary:


### PR DESCRIPTION
## Problem

On a tag push (release), `tag-experimental` was always set (e.g. `1.2.3-experimental`) and passed to `image-builder` alongside the release tag:

```yaml
tags: |
  ${{ needs.setup.outputs.tag }}
  ${{ needs.setup.outputs.tag-experimental }}   # ← always set on tag push
  ${{ needs.setup.outputs.latest }}
```

This caused the experimental image to be built and pushed to the registry as a side effect of every release, and may have interfered with the clean semver tag not landing correctly in artifactory.

## Fix

Remove `tag-experimental` from the `build-image` tags input and drop the now-unused output from `setup`, mirroring the KIM workflow:

```yaml
tags: |
  ${{ needs.setup.outputs.tag }}
  ${{ needs.setup.outputs.latest }}
```

## Behaviour after fix

| Trigger | tag | latest | tag-experimental |
|---|---|---|---|
| Tag push | ✅ pushed | skipped (empty) | ✅ not pushed |
| Push to main | skipped (empty) | ✅ pushed | n/a |
| PR | skipped | skipped | n/a |