### PR TITLE
Add component-config.yaml

### DIFF
--- a/component-config.yaml
+++ b/component-config.yaml
@@ -1,0 +1,4 @@
+name: kyma-project.io/kyma-runtime/kyma-components/registry-cache
+team: kyma/framefrog
+images:
+  - europe-docker.pkg.dev/kyma-project/prod/registry-cache:latest


### PR DESCRIPTION
## Summary

This PR adds a `component-config.yaml` file at the repository root.

The file lists the component metadata and images produced by this module, following the same pattern established in [infrastructure-manager](https://github.com/kyma-project/infrastructure-manager).

- **name**: `kyma-project.io/kyma-runtime/kyma-components/registry-cache`
- **team**: `kyma/framefrog`
- **images**: `europe-docker.pkg.dev/kyma-project/prod/registry-cache:latest`